### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ If your rsession crashes when you try to render rasterized plot, probably your v
 version of R (see [Upgrading to a new version of R](http://shiny.rstudio.com/articles/upgrade-R.html)). To check if 
 you use a proper version run the command below and ensure that "Built" version is the same as your R version.
 ```r
-pkgs <- as.data.frame(installed.packages(), stringsAsFactors = F, row.names = F)
+pkgs <- as.data.frame(installed.packages(), stringsAsFactors = FALSE, row.names = FALSE)
 pkgs[pkgs$Package == 'Cairo', c("Package", "LibPath", "Version", "Built")]
 ```
 


### PR DESCRIPTION
I would suggest not encouraging the F for FALSE shorthand. It is a terrible idea because T and F are not reserved keywords in R. For example, this is valid:

```r
F <- TRUE
if (F) print("F is now TRUE!")
```