### PR TITLE
Suggestion: Consideration of a scale factor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ language: r
 
 before_install:
   - sudo apt-get update -y 
-  - sudo apt-get -y install libglu1-mesa-dev libharfbuzz-dev libfribidi-dev 
+  - sudo apt-get -y install libglu1-mesa-dev libharfbuzz-dev libfribidi-dev libcairo2-dev
 
 script:
   - R CMD build . --compact-vignettes=gs+qpdf

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Changelog
 
 ## [0.2.3] - 
-* `rasterise()` changed to work with multiple layers
-* `rasterise()` now works with `geom_sf()`, i.e. should find any layers in a valid input list, and rasterize this. 
+* Function `rasterise()` changed to work with multiple layers
+* Function `rasterise()` now works with `geom_sf()`, i.e. should find any layers in a valid input list, and rasterize this. 
+* Parameter `scale` added to rasterise()`. This scales the 'height' and 'weight' of the raster objects
 
 ## [0.2.2] - 2021-02-10
 * Add global option for `dpi` using `options(ggrastr.default.dpi=N)`. PR found here: https://github.com/VPetukhov/ggrastr/pull/21

--- a/R/geom-beeswarm-rast.R
+++ b/R/geom-beeswarm-rast.R
@@ -4,13 +4,13 @@
 #'
 #' @import ggplot2
 #' @import ggbeeswarm
-#' @param priority Method used to perform point layout (see ggbeeswarm::position_beeswarm)
-#' @param cex Scaling for adjusting point spacing (see ggbeeswarm::position_beeswarm)
-#' @param groupOnX Should jitter be added to the x axis if TRUE or y axis if FALSE (the default NULL causes the function to guess which axis is the categorical one based on the number of unique entries in each) Refer to see ggbeeswarm::position_beeswarm
+#' @param priority string Method used to perform point layout (see ggbeeswarm::position_beeswarm). 
+#' @param cex numeric Scaling for adjusting point spacing (see ggbeeswarm::position_beeswarm)
+#' @param groupOnX boolean Should jitter be added to the x axis if TRUE or y axis if FALSE (the default NULL causes the function to guess which axis is the categorical one based on the number of unique entries in each). Refer to see ggbeeswarm::position_beeswarm
 #' @param dodge.width Amount by which points from different aesthetic groups will be dodged. This requires that one of the aesthetics is a factor. (see ggbeeswarm::position_beeswarm)
 #' @param raster.dpi An integer of length one setting the desired resolution in dots per inch. (default=300)
 #' @param dev A character specifying a device. Can be one of: \code{"cairo"}, \code{"ragg"} or \code{"ragg_png"}. (default="cairo")
-#' @param scale A numeric of length one, setting the scaling factor (default=1)
+#' @param scale numeric Scaling factor to modify the raster object size (default=1). The parameter 'scale=1' results in an object size that is unchanged, 'scale'>1 increase the size, and 'scale'<1 decreases the size. These parameters are passed to 'height' and 'width' of grid::grid.raster(). Please refer to 'rasterise()' and 'grid::grid.raster()' for more details.
 #' @return geom_beeswarm plot with rasterized layer
 #'
 #' @examples

--- a/R/geom-beeswarm-rast.R
+++ b/R/geom-beeswarm-rast.R
@@ -10,6 +10,7 @@
 #' @param dodge.width Amount by which points from different aesthetic groups will be dodged. This requires that one of the aesthetics is a factor. (see ggbeeswarm::position_beeswarm)
 #' @param raster.dpi An integer of length one setting the desired resolution in dots per inch. (default=300)
 #' @param dev A character specifying a device. Can be one of: \code{"cairo"}, \code{"ragg"} or \code{"ragg_png"}. (default="cairo")
+#' @param scale A numeric of length one, setting the scaling factor (default=1)
 #' @return geom_beeswarm plot with rasterized layer
 #'
 #' @examples
@@ -19,7 +20,7 @@
 #' ggplot(mtcars) + geom_beeswarm_rast(aes(x = factor(cyl), y = mpg), raster.dpi = 600, cex = 1.5)
 #'
 #' @export
-geom_beeswarm_rast <- function(..., priority= c("ascending", "descending", "density", "random", "none"), cex = 1, groupOnX = NULL, dodge.width = 0, raster.dpi = getOption("ggrastr.default.dpi", 300), dev="cairo") {
-  rasterise(ggbeeswarm::geom_beeswarm(..., priority=priority, cex=cex, groupOnX=groupOnX, dodge.width=dodge.width), dpi=raster.dpi, dev=dev)
+geom_beeswarm_rast <- function(..., priority= c("ascending", "descending", "density", "random", "none"), cex = 1, groupOnX = NULL, dodge.width = 0, raster.dpi = getOption("ggrastr.default.dpi", 300), dev="cairo", scale = 1) {
+  rasterise(ggbeeswarm::geom_beeswarm(..., priority=priority, cex=cex, groupOnX=groupOnX, dodge.width=dodge.width), dpi=raster.dpi, dev=dev, scale=scale)
 }
 

--- a/R/geom-boxplot-jitter.R
+++ b/R/geom-boxplot-jitter.R
@@ -2,11 +2,12 @@
 GeomPointRast <- ggplot2::ggproto(
   "GeomPointRast",
   ggplot2::GeomPoint,
-  draw_panel = function(self, data, panel_params, coord, raster.dpi, dev) {
+  draw_panel = function(self, data, panel_params, coord, raster.dpi, dev, scale) {
     grob <- ggproto_parent(GeomPoint, self)$draw_panel(data, panel_params, coord)
     class(grob) <- c("rasteriser", class(grob))
     grob$dpi <- raster.dpi
     grob$dev <- dev
+    grob$scale <- scale
     return(grob)
   }
 )
@@ -21,7 +22,8 @@ DrawGeomBoxplotJitter <- function(data, panel_params, coord, dev="cairo", ...,
                                   outlier.stroke = 0.5,
                                   outlier.alpha = NULL,
                                   raster=FALSE, raster.dpi=getOption("ggrastr.default.dpi", 300),
-                                  raster.width=NULL, raster.height=NULL
+                                  raster.width=NULL, raster.height=NULL,
+                                  scale = 1
                                   ) {
   boxplot_grob <- ggplot2::GeomBoxplot$draw_group(data, panel_params, coord, ...)
   point_grob <- grep("geom_point.*", names(boxplot_grob$children))
@@ -57,7 +59,7 @@ DrawGeomBoxplotJitter <- function(data, panel_params, coord, dev="cairo", ...,
     stringsAsFactors = FALSE
   )
 
-  boxplot_grob$children[[point_grob]] <- GeomPointRast$draw_panel(outliers, panel_params, coord, raster.dpi=raster.dpi, dev=dev)
+  boxplot_grob$children[[point_grob]] <- GeomPointRast$draw_panel(outliers, panel_params, coord, raster.dpi=raster.dpi, dev=dev, scale = scale)
 
   return(boxplot_grob)
 }
@@ -94,7 +96,8 @@ geom_boxplot_jitter <- function(mapping = NULL, data = NULL, dev = "cairo",
                                 inherit.aes = TRUE, ...,
                                 outlier.jitter.width=NULL,
                                 outlier.jitter.height=0,
-                                raster.dpi=getOption("ggrastr.default.dpi", 300)
+                                raster.dpi=getOption("ggrastr.default.dpi", 300),
+                                scale = 1
                                 ) {
   ggplot2::layer(
     geom = GeomBoxplotJitter, mapping = mapping, data = data, stat = stat,
@@ -102,5 +105,5 @@ geom_boxplot_jitter <- function(mapping = NULL, data = NULL, dev = "cairo",
     params = list(na.rm = na.rm,
                   outlier.jitter.width=outlier.jitter.width,
                   outlier.jitter.height=outlier.jitter.height,
-                  raster.dpi=raster.dpi, dev=dev, ...))
+                  raster.dpi=raster.dpi, dev=dev, scale = scale, ...))
 }

--- a/R/geom-boxplot-jitter.R
+++ b/R/geom-boxplot-jitter.R
@@ -79,6 +79,7 @@ GeomBoxplotJitter <- ggplot2::ggproto("GeomBoxplotJitter",
 #' so the total spread is twice the value specified here (default=0)
 #' @param raster.dpi Resolution of the rastered image (default=300). Ignored if \code{raster == FALSE}.
 #' @param dev A character specifying a device (default="cairo"). Can be one of: \code{"cairo"}, \code{"ragg"} or \code{"ragg_png"}.
+#' @param scale A numeric of length one, setting the scaling factor (default=1)
 #' @return geom_boxplot plot with rasterized layer
 #'
 #' @examples

--- a/R/geom-boxplot-jitter.R
+++ b/R/geom-boxplot-jitter.R
@@ -79,7 +79,7 @@ GeomBoxplotJitter <- ggplot2::ggproto("GeomBoxplotJitter",
 #' so the total spread is twice the value specified here (default=0)
 #' @param raster.dpi Resolution of the rastered image (default=300). Ignored if \code{raster == FALSE}.
 #' @param dev A character specifying a device (default="cairo"). Can be one of: \code{"cairo"}, \code{"ragg"} or \code{"ragg_png"}.
-#' @param scale A numeric of length one, setting the scaling factor (default=1)
+#' @param scale numeric Scaling factor to modify the raster object size (default=1). The parameter 'scale=1' results in an object size that is unchanged, 'scale'>1 increase the size, and 'scale'<1 decreases the size. These parameters are passed to 'height' and 'width' of grid::grid.raster(). Please refer to 'rasterise()' and 'grid::grid.raster()' for more details.
 #' @return geom_boxplot plot with rasterized layer
 #'
 #' @examples

--- a/R/geom-jitter-rast.R
+++ b/R/geom-jitter-rast.R
@@ -5,6 +5,7 @@
 #' @import ggplot2
 #' @param raster.dpi An integer of length one setting the desired resolution in dots per inch. (default=300)
 #' @param dev A character specifying a device. Can be one of: \code{"cairo"}, \code{"ragg"} or \code{"ragg_png"}. (default="cairo")
+#' @param scale A numeric of length one, setting the scaling factor (default=1)
 #' @return geom_point_rast plot with rasterized layer
 #'
 #' @examples
@@ -14,6 +15,6 @@
 #' ggplot(mpg) + geom_jitter_rast(aes(x = factor(cyl), y = hwy), raster.dpi = 600)
 #'
 #' @export
-geom_jitter_rast <- function(..., raster.dpi = getOption("ggrastr.default.dpi", 300), dev="cairo"){
-  rasterise(geom_jitter(...), dpi=raster.dpi, dev=dev)
+geom_jitter_rast <- function(..., raster.dpi = getOption("ggrastr.default.dpi", 300), dev="cairo", scale=1){
+  rasterise(geom_jitter(...), dpi=raster.dpi, dev=dev, scale=scale)
 }

--- a/R/geom-jitter-rast.R
+++ b/R/geom-jitter-rast.R
@@ -5,7 +5,7 @@
 #' @import ggplot2
 #' @param raster.dpi An integer of length one setting the desired resolution in dots per inch. (default=300)
 #' @param dev A character specifying a device. Can be one of: \code{"cairo"}, \code{"ragg"} or \code{"ragg_png"}. (default="cairo")
-#' @param scale A numeric of length one, setting the scaling factor (default=1)
+#' @param scale numeric Scaling factor to modify the raster object size (default=1). The parameter 'scale=1' results in an object size that is unchanged, 'scale'>1 increase the size, and 'scale'<1 decreases the size. These parameters are passed to 'height' and 'width' of grid::grid.raster(). Please refer to 'rasterise()' and 'grid::grid.raster()' for more details.
 #' @return geom_point_rast plot with rasterized layer
 #'
 #' @examples

--- a/R/geom-point-rast.R
+++ b/R/geom-point-rast.R
@@ -6,6 +6,7 @@
 #' @import ggplot2
 #' @param raster.dpi An integer of length one setting the desired resolution in dots per inch. (default=300)
 #' @param dev A character specifying a device. Can be one of: \code{"cairo"}, \code{"ragg"} or \code{"ragg_png"}. (default="cairo")
+#' @param scale A numeric of length one, setting the scaling factor (default=1)
 #' @return geom_point plot with rasterized layer
 #'
 #' @examples
@@ -15,6 +16,6 @@
 #' ggplot() + geom_point_rast(aes(x=rnorm(1000), y=rnorm(1000)), raster.dpi=600)
 #'
 #' @export
-geom_point_rast <- function(..., raster.dpi=getOption("ggrastr.default.dpi", 300), dev="cairo") {
-  rasterise(geom_point(...), dpi=raster.dpi, dev=dev)
+geom_point_rast <- function(..., raster.dpi=getOption("ggrastr.default.dpi", 300), dev="cairo", scale=1) {
+  rasterise(geom_point(...), dpi=raster.dpi, dev=dev, scale=scale)
 }

--- a/R/geom-point-rast.R
+++ b/R/geom-point-rast.R
@@ -6,7 +6,7 @@
 #' @import ggplot2
 #' @param raster.dpi An integer of length one setting the desired resolution in dots per inch. (default=300)
 #' @param dev A character specifying a device. Can be one of: \code{"cairo"}, \code{"ragg"} or \code{"ragg_png"}. (default="cairo")
-#' @param scale A numeric of length one, setting the scaling factor (default=1)
+#' @param scale numeric Scaling factor to modify the raster object size (default=1). The parameter 'scale=1' results in an object size that is unchanged, 'scale'>1 increase the size, and 'scale'<1 decreases the size. These parameters are passed to 'height' and 'width' of grid::grid.raster(). Please refer to 'rasterise()' and 'grid::grid.raster()' for more details.
 #' @return geom_point plot with rasterized layer
 #'
 #' @examples

--- a/R/geom-quasirandom-rast.R
+++ b/R/geom-quasirandom-rast.R
@@ -5,7 +5,7 @@
 #' @inheritSection ggplot2::geom_point Aesthetics
 #' @param raster.dpi An integer of length one setting the desired resolution in dots per inch. (default=300)
 #' @param dev A character specifying a device. Can be one of: \code{"cairo"}, \code{"ragg"} or \code{"ragg_png"}. (default="cairo")
-#' @param scale A numeric of length one, setting the scaling factor (default=1)
+#' @param scale numeric Scaling factor to modify the raster object size (default=1). The parameter 'scale=1' results in an object size that is unchanged, 'scale'>1 increase the size, and 'scale'<1 decreases the size. These parameters are passed to 'height' and 'width' of grid::grid.raster(). Please refer to 'rasterise()' and 'grid::grid.raster()' for more details.
 #' @return geom_quasirandom plot with rasterized layer
 #'
 #' @examples

--- a/R/geom-quasirandom-rast.R
+++ b/R/geom-quasirandom-rast.R
@@ -5,6 +5,7 @@
 #' @inheritSection ggplot2::geom_point Aesthetics
 #' @param raster.dpi An integer of length one setting the desired resolution in dots per inch. (default=300)
 #' @param dev A character specifying a device. Can be one of: \code{"cairo"}, \code{"ragg"} or \code{"ragg_png"}. (default="cairo")
+#' @param scale A numeric of length one, setting the scaling factor (default=1)
 #' @return geom_quasirandom plot with rasterized layer
 #'
 #' @examples
@@ -14,6 +15,6 @@
 #' ggplot(mtcars) + geom_quasirandom_rast(aes(x = factor(cyl), y = mpg), raster.dpi = 600)
 #'
 #' @export
-geom_quasirandom_rast <- function(..., width = NULL, varwidth = FALSE, bandwidth = 0.5, nbins = NULL, method = "quasirandom", groupOnX = NULL, dodge.width = 0, raster.dpi = getOption("ggrastr.default.dpi", 300), dev="cairo") {
-  rasterise(ggbeeswarm::geom_quasirandom(..., width = width, varwidth = varwidth, bandwidth = bandwidth, nbins = nbins, method = method, groupOnX = groupOnX, dodge.width = dodge.width), dpi=raster.dpi, dev=dev)
+geom_quasirandom_rast <- function(..., width = NULL, varwidth = FALSE, bandwidth = 0.5, nbins = NULL, method = "quasirandom", groupOnX = NULL, dodge.width = 0, raster.dpi = getOption("ggrastr.default.dpi", 300), dev="cairo", scale=1) {
+  rasterise(ggbeeswarm::geom_quasirandom(..., width = width, varwidth = varwidth, bandwidth = bandwidth, nbins = nbins, method = method, groupOnX = groupOnX, dodge.width = dodge.width), dpi=raster.dpi, dev=dev, scale=scale)
 }

--- a/R/geom-tile-rast.R
+++ b/R/geom-tile-rast.R
@@ -5,6 +5,7 @@
 #'
 #' @param raster.dpi An integer of length one setting the desired resolution in dots per inch. (default=300)
 #' @param dev A character specifying a device. Can be one of: \code{"cairo"}, \code{"ragg"} or \code{"ragg_png"}. (default="cairo")
+#' @param scale A numeric of length one, setting the scaling factor (default=1)
 #' @return geom_tile plot with rasterized layer
 #'
 #' @examples
@@ -16,6 +17,6 @@
 #' ggplot(coords) + geom_tile_rast(aes(x=Var1, y=Var2, fill=Value))
 #'
 #' @export
-geom_tile_rast <- function(..., raster.dpi=getOption("ggrastr.default.dpi", 300), dev="cairo") {
-  rasterise(geom_tile(...), dpi=raster.dpi, dev=dev)
+geom_tile_rast <- function(..., raster.dpi=getOption("ggrastr.default.dpi", 300), dev="cairo", scale=scale) {
+  rasterise(geom_tile(...), dpi=raster.dpi, dev=dev, scale=scale)
 }

--- a/R/geom-tile-rast.R
+++ b/R/geom-tile-rast.R
@@ -5,7 +5,7 @@
 #'
 #' @param raster.dpi An integer of length one setting the desired resolution in dots per inch. (default=300)
 #' @param dev A character specifying a device. Can be one of: \code{"cairo"}, \code{"ragg"} or \code{"ragg_png"}. (default="cairo")
-#' @param scale A numeric of length one, setting the scaling factor (default=1)
+#' @param scale numeric Scaling factor to modify the raster object size (default=1). The parameter 'scale=1' results in an object size that is unchanged, 'scale'>1 increase the size, and 'scale'<1 decreases the size. These parameters are passed to 'height' and 'width' of grid::grid.raster(). Please refer to 'rasterise()' and 'grid::grid.raster()' for more details.
 #' @return geom_tile plot with rasterized layer
 #'
 #' @examples

--- a/R/geom-tile-rast.R
+++ b/R/geom-tile-rast.R
@@ -17,6 +17,6 @@
 #' ggplot(coords) + geom_tile_rast(aes(x=Var1, y=Var2, fill=Value))
 #'
 #' @export
-geom_tile_rast <- function(..., raster.dpi=getOption("ggrastr.default.dpi", 300), dev="cairo", scale=scale) {
+geom_tile_rast <- function(..., raster.dpi=getOption("ggrastr.default.dpi", 300), dev="cairo", scale=1) {
   rasterise(geom_tile(...), dpi=raster.dpi, dev=dev, scale=scale)
 }

--- a/R/geom-violin-rast.R
+++ b/R/geom-violin-rast.R
@@ -5,7 +5,7 @@
 #'
 #' @param raster.dpi An integer of length one setting the desired resolution in dots per inch. (default=300)
 #' @param dev A character specifying a device. Can be one of: \code{"cairo"}, \code{"ragg"} or \code{"ragg_png"}. (default="cairo")
-#' @param scale A numeric of length one, setting the scaling factor (default=1)
+#' @param scale numeric Scaling factor to modify the raster object size (default=1). The parameter 'scale=1' results in an object size that is unchanged, 'scale'>1 increase the size, and 'scale'<1 decreases the size. These parameters are passed to 'height' and 'width' of grid::grid.raster(). Please refer to 'rasterise()' and 'grid::grid.raster()' for more details.
 #' @return geom_violin_rast plot with rasterized layer
 #'
 #' @examples

--- a/R/geom-violin-rast.R
+++ b/R/geom-violin-rast.R
@@ -5,6 +5,7 @@
 #'
 #' @param raster.dpi An integer of length one setting the desired resolution in dots per inch. (default=300)
 #' @param dev A character specifying a device. Can be one of: \code{"cairo"}, \code{"ragg"} or \code{"ragg_png"}. (default="cairo")
+#' @param scale A numeric of length one, setting the scaling factor (default=1)
 #' @return geom_violin_rast plot with rasterized layer
 #'
 #' @examples
@@ -14,6 +15,6 @@
 #' ggplot(mpg) + geom_violin_rast(aes(x = factor(cyl), y = hwy), raster.dpi = 600)
 #'
 #' @export
-geom_violin_rast = function(..., raster.dpi=getOption("ggrastr.default.dpi", 300), dev="cairo"){
-  rasterise(geom_violin(...), dpi=raster.dpi, dev=dev)
+geom_violin_rast = function(..., raster.dpi=getOption("ggrastr.default.dpi", 300), dev="cairo", scale=1){
+  rasterise(geom_violin(...), dpi=raster.dpi, dev=dev, scale=scale)
 }

--- a/R/rasterise.R
+++ b/R/rasterise.R
@@ -45,6 +45,7 @@ rasterise <- function(layer, dpi = getOption("ggrastr.default.dpi"), dev = "cair
         class(grob) <- c("rasteriser", class(grob))
         grob$dpi <- dpi
         grob$dev <- dev
+        grob$scale <- scale
         return(grob)
       }
     )
@@ -62,8 +63,8 @@ rasterize <- rasterise
 makeContext.rasteriser <- function(x) {
   # Grab viewport information
   vp <- if(is.null(x$vp)) grid::viewport() else x$vp
-  width <- grid::convertWidth(unit(1, "npc"), "inch", valueOnly = TRUE)*scale
-  height <- grid::convertHeight(unit(1, "npc"), "inch", valueOnly = TRUE)*scale
+  width <- grid::convertWidth(unit(1, "npc"), "inch", valueOnly = TRUE)
+  height <- grid::convertHeight(unit(1, "npc"), "inch", valueOnly = TRUE)
 
   # Grab grob metadata
   dpi <- x$dpi
@@ -72,12 +73,18 @@ makeContext.rasteriser <- function(x) {
     dpi <- grid::convertWidth(unit(1, "inch"), "pt", valueOnly = TRUE)
   }
   dev <- x$dev
+  scale <- x$scale
 
   # Clean up grob
   x$dev <- NULL
   x$dpi <- NULL
+  x$scale <- NULL
   class(x) <- setdiff(class(x), "rasteriser")
 
+  # Rescale height and width
+  width <- width * scale
+  height <- height * scale
+  
   # Track current device
   dev_cur <- grDevices::dev.cur()
   # Reset current device upon function exit

--- a/R/rasterise.R
+++ b/R/rasterise.R
@@ -142,14 +142,11 @@ makeContext.rasteriser <- function(x) {
     )
   }
 
-  #back transform scaling
-  height <-height / scale
-  width <- width / scale
   # Forward raster grob
   grid::rasterGrob(
     cap, x = 0.5, y = 0.5,
-    height = unit(height, "inch"),
-    width = unit(width, "inch"),
+    height = unit(height / scale, "inch"),
+    width = unit(width / scale, "inch"),
     default.units = "npc",
     just = "center"
   )

--- a/R/rasterise.R
+++ b/R/rasterise.R
@@ -84,7 +84,7 @@ makeContext.rasteriser <- function(x) {
   # Rescale height and width
   width <- width * scale
   height <- height * scale
-  
+
   # Track current device
   dev_cur <- grDevices::dev.cur()
   # Reset current device upon function exit
@@ -142,11 +142,14 @@ makeContext.rasteriser <- function(x) {
     )
   }
 
+  #back transform scaling
+  height <-height / scale
+  width <- width / scale
   # Forward raster grob
   grid::rasterGrob(
     cap, x = 0.5, y = 0.5,
-    height = unit(height/scale, "inch"),
-    width = unit(width/scale, "inch"),
+    height = unit(height, "inch"),
+    width = unit(width, "inch"),
     default.units = "npc",
     just = "center"
   )

--- a/R/rasterise.R
+++ b/R/rasterise.R
@@ -6,7 +6,7 @@
 #'   \code{geom_*()} or \code{stat_*()} function.
 #' @param dpi An integer of length one setting the desired resolution in dots per inch. (default=NULL)
 #' @param dev A character specifying a device. Can be one of: \code{"cairo"}, \code{"ragg"} or \code{"ragg_png"}. (default="cairo")
-#' @param scale A numeric of length one, setting the scaling factor (default=1)
+#' @param scale A numeric of length one, setting the scaling factor (default=1). Values > 1 will render the plot as if it was plotted in a larger window.
 #' @details The default \code{dpi} (\code{NULL} (= let device decide)) can conveniently be controlled by setting the option \code{"ggrastr.default.dpi"} (e.g. \code{option("ggrastr.default.dpi", 30)} for drafting).
 #' @return A modified \code{Layer} object.
 #' @examples
@@ -87,6 +87,10 @@ makeContext.rasteriser <- function(x) {
   class(x) <- setdiff(class(x), "rasteriser")
 
   # Rescale height and width
+  if (scale < 0 | !is.numeric(scale)) {
+    stop("scale must be set to a numeric > 0")
+  }
+
   width <- width * scale
   height <- height * scale
 

--- a/R/rasterise.R
+++ b/R/rasterise.R
@@ -83,7 +83,11 @@ rasterize <- rasterise
 #' @method makeContext rasteriser
 makeContext.rasteriser <- function(x) {
   # Grab viewport information
-  vp <- if(is.null(x$vp)) grid::viewport() else x$vp
+  vp <- if (is.null(x$vp)){
+    grid::viewport()
+  } else{
+    x$vp
+  }
   width <- grid::convertWidth(unit(1, "npc"), "inch", valueOnly = TRUE)
   height <- grid::convertHeight(unit(1, "npc"), "inch", valueOnly = TRUE)
 
@@ -103,8 +107,8 @@ makeContext.rasteriser <- function(x) {
   class(x) <- setdiff(class(x), "rasteriser")
 
   # Rescale height and width
-  if (scale < 0 | !is.numeric(scale)) {
-    stop("scale must be set to a numeric > 0")
+  if (scale <= 0 || !is.numeric(scale)) {
+    stop("The parameter 'scale' must be set to a numeric greater than 0")
   }
 
   width <- width * scale

--- a/R/rasterise.R
+++ b/R/rasterise.R
@@ -24,7 +24,7 @@
 #'   rasterise(stat_summary_hex(), dev = "ragg")
 #'
 #' @export
-rasterise <- function(layer, dpi = getOption("ggrastr.default.dpi"), dev = "cairo") {
+rasterise <- function(layer, dpi = getOption("ggrastr.default.dpi"), dev = "cairo", scale = 1) {
   dev <- match.arg(dev, c("cairo", "ragg", "ragg_png"))
 
   if (!inherits(layer, "Layer")) {
@@ -62,8 +62,8 @@ rasterize <- rasterise
 makeContext.rasteriser <- function(x) {
   # Grab viewport information
   vp <- if(is.null(x$vp)) grid::viewport() else x$vp
-  width <- grid::convertWidth(unit(1, "npc"), "inch", valueOnly = TRUE)
-  height <- grid::convertHeight(unit(1, "npc"), "inch", valueOnly = TRUE)
+  width <- grid::convertWidth(unit(1, "npc"), "inch", valueOnly = TRUE)*scale
+  height <- grid::convertHeight(unit(1, "npc"), "inch", valueOnly = TRUE)*scale
 
   # Grab grob metadata
   dpi <- x$dpi

--- a/R/rasterise.R
+++ b/R/rasterise.R
@@ -6,7 +6,7 @@
 #'   \code{geom_*()} or \code{stat_*()} function.
 #' @param dpi An integer of length one setting the desired resolution in dots per inch. (default=NULL)
 #' @param dev A character specifying a device. Can be one of: \code{"cairo"}, \code{"ragg"} or \code{"ragg_png"}. (default="cairo")
-#' @param scale A numeric of length one, setting the scaling factor (default=1). Values > 1 will render the plot as if it was plotted in a larger window.
+#' @param scale numeric Scaling factor to modify the raster object size (default=1). The parameter 'scale=1' results in an object size that is unchanged, 'scale'>1 increase the size, and 'scale'<1 decreases the size. These parameters are passed to 'height' and 'width' of grid::grid.raster(). Please refer to 'rasterise()' and 'grid::grid.raster()' for more details.
 #' @details The default \code{dpi} (\code{NULL} (= let device decide)) can conveniently be controlled by setting the option \code{"ggrastr.default.dpi"} (e.g. \code{option("ggrastr.default.dpi", 30)} for drafting).
 #' @return A modified \code{Layer} object.
 #' @examples
@@ -111,8 +111,8 @@ makeContext.rasteriser <- function(x) {
     stop("The parameter 'scale' must be set to a numeric greater than 0")
   }
 
-  width <- width * scale
-  height <- height * scale
+  width <- width / scale
+  height <- height / scale
 
   # Track current device
   dev_cur <- grDevices::dev.cur()
@@ -174,8 +174,8 @@ makeContext.rasteriser <- function(x) {
   # Forward raster grob
   grid::rasterGrob(
     cap, x = 0.5, y = 0.5,
-    height = unit(height / scale, "inch"),
-    width = unit(width / scale, "inch"),
+    height = unit(height * scale, "inch"),
+    width = unit(width * scale, "inch"),
     default.units = "npc",
     just = "center"
   )

--- a/R/rasterise.R
+++ b/R/rasterise.R
@@ -6,6 +6,7 @@
 #'   \code{geom_*()} or \code{stat_*()} function.
 #' @param dpi An integer of length one setting the desired resolution in dots per inch. (default=NULL)
 #' @param dev A character specifying a device. Can be one of: \code{"cairo"}, \code{"ragg"} or \code{"ragg_png"}. (default="cairo")
+#' @param scale A numeric of length one, setting the scaling factor (default=1)
 #' @details The default \code{dpi} (\code{NULL} (= let device decide)) can conveniently be controlled by setting the option \code{"ggrastr.default.dpi"} (e.g. \code{option("ggrastr.default.dpi", 30)} for drafting).
 #' @return A modified \code{Layer} object.
 #' @examples
@@ -22,6 +23,10 @@
 #' require(ragg)
 #' ggplot(diamonds, aes(carat, depth, z = price)) +
 #'   rasterise(stat_summary_hex(), dev = "ragg")
+#'
+#' # The `scale` argument allows you to render a 'big' plot in small window, or vice versa.
+#' ggplot(faithful, aes(eruptions, waiting)) +
+#'   rasterise(geom_point(), scale = 4)
 #'
 #' @export
 rasterise <- function(layer, dpi = getOption("ggrastr.default.dpi"), dev = "cairo", scale = 1) {

--- a/R/rasterise.R
+++ b/R/rasterise.R
@@ -145,8 +145,8 @@ makeContext.rasteriser <- function(x) {
   # Forward raster grob
   grid::rasterGrob(
     cap, x = 0.5, y = 0.5,
-    height = unit(height, "inch"),
-    width = unit(width, "inch"),
+    height = unit(height/scale, "inch"),
+    width = unit(width/scale, "inch"),
     default.units = "npc",
     just = "center"
   )

--- a/man/geom_beeswarm_rast.Rd
+++ b/man/geom_beeswarm_rast.Rd
@@ -21,11 +21,11 @@ often aesthetics, used to set an aesthetic to a fixed value, like
 \code{colour = "red"} or \code{size = 3}. They may also be parameters
 to the paired geom/stat.}
 
-\item{priority}{Method used to perform point layout (see ggbeeswarm::position_beeswarm)}
+\item{priority}{string Method used to perform point layout (see ggbeeswarm::position_beeswarm).}
 
-\item{cex}{Scaling for adjusting point spacing (see ggbeeswarm::position_beeswarm)}
+\item{cex}{numeric Scaling for adjusting point spacing (see ggbeeswarm::position_beeswarm)}
 
-\item{groupOnX}{Should jitter be added to the x axis if TRUE or y axis if FALSE (the default NULL causes the function to guess which axis is the categorical one based on the number of unique entries in each) Refer to see ggbeeswarm::position_beeswarm}
+\item{groupOnX}{boolean Should jitter be added to the x axis if TRUE or y axis if FALSE (the default NULL causes the function to guess which axis is the categorical one based on the number of unique entries in each). Refer to see ggbeeswarm::position_beeswarm}
 
 \item{dodge.width}{Amount by which points from different aesthetic groups will be dodged. This requires that one of the aesthetics is a factor. (see ggbeeswarm::position_beeswarm)}
 
@@ -33,7 +33,7 @@ to the paired geom/stat.}
 
 \item{dev}{A character specifying a device. Can be one of: \code{"cairo"}, \code{"ragg"} or \code{"ragg_png"}. (default="cairo")}
 
-\item{scale}{A numeric of length one, setting the scaling factor (default=1)}
+\item{scale}{numeric Scaling factor to modify the raster object size (default=1). The parameter 'scale=1' results in an object size that is unchanged, 'scale'>1 increase the size, and 'scale'<1 decreases the size. These parameters are passed to 'height' and 'width' of grid::grid.raster(). Please refer to 'rasterise()' and 'grid::grid.raster()' for more details.}
 }
 \value{
 geom_beeswarm plot with rasterized layer

--- a/man/geom_beeswarm_rast.Rd
+++ b/man/geom_beeswarm_rast.Rd
@@ -11,7 +11,8 @@ geom_beeswarm_rast(
   groupOnX = NULL,
   dodge.width = 0,
   raster.dpi = getOption("ggrastr.default.dpi", 300),
-  dev = "cairo"
+  dev = "cairo",
+  scale = 1
 )
 }
 \arguments{
@@ -31,6 +32,8 @@ to the paired geom/stat.}
 \item{raster.dpi}{An integer of length one setting the desired resolution in dots per inch. (default=300)}
 
 \item{dev}{A character specifying a device. Can be one of: \code{"cairo"}, \code{"ragg"} or \code{"ragg_png"}. (default="cairo")}
+
+\item{scale}{A numeric of length one, setting the scaling factor (default=1)}
 }
 \value{
 geom_beeswarm plot with rasterized layer

--- a/man/geom_boxplot_jitter.Rd
+++ b/man/geom_boxplot_jitter.Rd
@@ -44,7 +44,7 @@ from a \code{formula} (e.g. \code{~ head(.x, 10)}).}
 \item{dev}{A character specifying a device (default="cairo"). Can be one of: \code{"cairo"}, \code{"ragg"} or \code{"ragg_png"}.}
 
 \item{stat}{Use to override the default connection between
-\code{geom_boxplot} and \code{stat_boxplot}.}
+\code{geom_boxplot()} and \code{stat_boxplot()}.}
 
 \item{position}{Position adjustment, either as a string, or the result of
 a call to a position adjustment function.}
@@ -76,7 +76,7 @@ so the total spread is twice the value specified here (default=0)}
 
 \item{raster.dpi}{Resolution of the rastered image (default=300). Ignored if \code{raster == FALSE}.}
 
-\item{scale}{A numeric of length one, setting the scaling factor (default=1)}
+\item{scale}{numeric Scaling factor to modify the raster object size (default=1). The parameter 'scale=1' results in an object size that is unchanged, 'scale'>1 increase the size, and 'scale'<1 decreases the size. These parameters are passed to 'height' and 'width' of grid::grid.raster(). Please refer to 'rasterise()' and 'grid::grid.raster()' for more details.}
 }
 \value{
 geom_boxplot plot with rasterized layer

--- a/man/geom_boxplot_jitter.Rd
+++ b/man/geom_boxplot_jitter.Rd
@@ -16,7 +16,8 @@ geom_boxplot_jitter(
   ...,
   outlier.jitter.width = NULL,
   outlier.jitter.height = 0,
-  raster.dpi = getOption("ggrastr.default.dpi", 300)
+  raster.dpi = getOption("ggrastr.default.dpi", 300),
+  scale = 1
 )
 }
 \arguments{
@@ -43,7 +44,7 @@ from a \code{formula} (e.g. \code{~ head(.x, 10)}).}
 \item{dev}{A character specifying a device (default="cairo"). Can be one of: \code{"cairo"}, \code{"ragg"} or \code{"ragg_png"}.}
 
 \item{stat}{Use to override the default connection between
-\code{geom_boxplot()} and \code{stat_boxplot()}.}
+\code{geom_boxplot} and \code{stat_boxplot}.}
 
 \item{position}{Position adjustment, either as a string, or the result of
 a call to a position adjustment function.}
@@ -74,6 +75,8 @@ so the total spread is twice the value specified here (default=NULL)}
 so the total spread is twice the value specified here (default=0)}
 
 \item{raster.dpi}{Resolution of the rastered image (default=300). Ignored if \code{raster == FALSE}.}
+
+\item{scale}{A numeric of length one, setting the scaling factor (default=1)}
 }
 \value{
 geom_boxplot plot with rasterized layer

--- a/man/geom_jitter_rast.Rd
+++ b/man/geom_jitter_rast.Rd
@@ -21,7 +21,7 @@ to the paired geom/stat.}
 
 \item{dev}{A character specifying a device. Can be one of: \code{"cairo"}, \code{"ragg"} or \code{"ragg_png"}. (default="cairo")}
 
-\item{scale}{A numeric of length one, setting the scaling factor (default=1)}
+\item{scale}{numeric Scaling factor to modify the raster object size (default=1). The parameter 'scale=1' results in an object size that is unchanged, 'scale'>1 increase the size, and 'scale'<1 decreases the size. These parameters are passed to 'height' and 'width' of grid::grid.raster(). Please refer to 'rasterise()' and 'grid::grid.raster()' for more details.}
 }
 \value{
 geom_point_rast plot with rasterized layer

--- a/man/geom_jitter_rast.Rd
+++ b/man/geom_jitter_rast.Rd
@@ -7,7 +7,8 @@
 geom_jitter_rast(
   ...,
   raster.dpi = getOption("ggrastr.default.dpi", 300),
-  dev = "cairo"
+  dev = "cairo",
+  scale = 1
 )
 }
 \arguments{
@@ -19,6 +20,8 @@ to the paired geom/stat.}
 \item{raster.dpi}{An integer of length one setting the desired resolution in dots per inch. (default=300)}
 
 \item{dev}{A character specifying a device. Can be one of: \code{"cairo"}, \code{"ragg"} or \code{"ragg_png"}. (default="cairo")}
+
+\item{scale}{A numeric of length one, setting the scaling factor (default=1)}
 }
 \value{
 geom_point_rast plot with rasterized layer

--- a/man/geom_point_rast.Rd
+++ b/man/geom_point_rast.Rd
@@ -21,7 +21,7 @@ to the paired geom/stat.}
 
 \item{dev}{A character specifying a device. Can be one of: \code{"cairo"}, \code{"ragg"} or \code{"ragg_png"}. (default="cairo")}
 
-\item{scale}{A numeric of length one, setting the scaling factor (default=1)}
+\item{scale}{numeric Scaling factor to modify the raster object size (default=1). The parameter 'scale=1' results in an object size that is unchanged, 'scale'>1 increase the size, and 'scale'<1 decreases the size. These parameters are passed to 'height' and 'width' of grid::grid.raster(). Please refer to 'rasterise()' and 'grid::grid.raster()' for more details.}
 }
 \value{
 geom_point plot with rasterized layer

--- a/man/geom_point_rast.Rd
+++ b/man/geom_point_rast.Rd
@@ -7,7 +7,8 @@
 geom_point_rast(
   ...,
   raster.dpi = getOption("ggrastr.default.dpi", 300),
-  dev = "cairo"
+  dev = "cairo",
+  scale = 1
 )
 }
 \arguments{
@@ -19,6 +20,8 @@ to the paired geom/stat.}
 \item{raster.dpi}{An integer of length one setting the desired resolution in dots per inch. (default=300)}
 
 \item{dev}{A character specifying a device. Can be one of: \code{"cairo"}, \code{"ragg"} or \code{"ragg_png"}. (default="cairo")}
+
+\item{scale}{A numeric of length one, setting the scaling factor (default=1)}
 }
 \value{
 geom_point plot with rasterized layer

--- a/man/geom_quasirandom_rast.Rd
+++ b/man/geom_quasirandom_rast.Rd
@@ -43,7 +43,7 @@ Smaller numbers (< 1) produce a tighter "fit". (default: 0.5)}
 
 \item{dev}{A character specifying a device. Can be one of: \code{"cairo"}, \code{"ragg"} or \code{"ragg_png"}. (default="cairo")}
 
-\item{scale}{A numeric of length one, setting the scaling factor (default=1)}
+\item{scale}{numeric Scaling factor to modify the raster object size (default=1). The parameter 'scale=1' results in an object size that is unchanged, 'scale'>1 increase the size, and 'scale'<1 decreases the size. These parameters are passed to 'height' and 'width' of grid::grid.raster(). Please refer to 'rasterise()' and 'grid::grid.raster()' for more details.}
 }
 \value{
 geom_quasirandom plot with rasterized layer

--- a/man/geom_quasirandom_rast.Rd
+++ b/man/geom_quasirandom_rast.Rd
@@ -14,7 +14,8 @@ geom_quasirandom_rast(
   groupOnX = NULL,
   dodge.width = 0,
   raster.dpi = getOption("ggrastr.default.dpi", 300),
-  dev = "cairo"
+  dev = "cairo",
+  scale = 1
 )
 }
 \arguments{
@@ -41,6 +42,8 @@ Smaller numbers (< 1) produce a tighter "fit". (default: 0.5)}
 \item{raster.dpi}{An integer of length one setting the desired resolution in dots per inch. (default=300)}
 
 \item{dev}{A character specifying a device. Can be one of: \code{"cairo"}, \code{"ragg"} or \code{"ragg_png"}. (default="cairo")}
+
+\item{scale}{A numeric of length one, setting the scaling factor (default=1)}
 }
 \value{
 geom_quasirandom plot with rasterized layer

--- a/man/geom_tile_rast.Rd
+++ b/man/geom_tile_rast.Rd
@@ -7,7 +7,8 @@
 geom_tile_rast(
   ...,
   raster.dpi = getOption("ggrastr.default.dpi", 300),
-  dev = "cairo"
+  dev = "cairo",
+  scale = scale
 )
 }
 \arguments{
@@ -19,6 +20,8 @@ to the paired geom/stat.}
 \item{raster.dpi}{An integer of length one setting the desired resolution in dots per inch. (default=300)}
 
 \item{dev}{A character specifying a device. Can be one of: \code{"cairo"}, \code{"ragg"} or \code{"ragg_png"}. (default="cairo")}
+
+\item{scale}{A numeric of length one, setting the scaling factor (default=1)}
 }
 \value{
 geom_tile plot with rasterized layer

--- a/man/geom_tile_rast.Rd
+++ b/man/geom_tile_rast.Rd
@@ -21,7 +21,7 @@ to the paired geom/stat.}
 
 \item{dev}{A character specifying a device. Can be one of: \code{"cairo"}, \code{"ragg"} or \code{"ragg_png"}. (default="cairo")}
 
-\item{scale}{A numeric of length one, setting the scaling factor (default=1)}
+\item{scale}{numeric Scaling factor to modify the raster object size (default=1). The parameter 'scale=1' results in an object size that is unchanged, 'scale'>1 increase the size, and 'scale'<1 decreases the size. These parameters are passed to 'height' and 'width' of grid::grid.raster(). Please refer to 'rasterise()' and 'grid::grid.raster()' for more details.}
 }
 \value{
 geom_tile plot with rasterized layer

--- a/man/geom_tile_rast.Rd
+++ b/man/geom_tile_rast.Rd
@@ -8,7 +8,7 @@ geom_tile_rast(
   ...,
   raster.dpi = getOption("ggrastr.default.dpi", 300),
   dev = "cairo",
-  scale = scale
+  scale = 1
 )
 }
 \arguments{

--- a/man/geom_violin_rast.Rd
+++ b/man/geom_violin_rast.Rd
@@ -7,7 +7,8 @@
 geom_violin_rast(
   ...,
   raster.dpi = getOption("ggrastr.default.dpi", 300),
-  dev = "cairo"
+  dev = "cairo",
+  scale = 1
 )
 }
 \arguments{
@@ -19,6 +20,8 @@ to the paired geom/stat.}
 \item{raster.dpi}{An integer of length one setting the desired resolution in dots per inch. (default=300)}
 
 \item{dev}{A character specifying a device. Can be one of: \code{"cairo"}, \code{"ragg"} or \code{"ragg_png"}. (default="cairo")}
+
+\item{scale}{A numeric of length one, setting the scaling factor (default=1)}
 }
 \value{
 geom_violin_rast plot with rasterized layer

--- a/man/geom_violin_rast.Rd
+++ b/man/geom_violin_rast.Rd
@@ -21,7 +21,7 @@ to the paired geom/stat.}
 
 \item{dev}{A character specifying a device. Can be one of: \code{"cairo"}, \code{"ragg"} or \code{"ragg_png"}. (default="cairo")}
 
-\item{scale}{A numeric of length one, setting the scaling factor (default=1)}
+\item{scale}{numeric Scaling factor to modify the raster object size (default=1). The parameter 'scale=1' results in an object size that is unchanged, 'scale'>1 increase the size, and 'scale'<1 decreases the size. These parameters are passed to 'height' and 'width' of grid::grid.raster(). Please refer to 'rasterise()' and 'grid::grid.raster()' for more details.}
 }
 \value{
 geom_violin_rast plot with rasterized layer

--- a/man/rasterise.Rd
+++ b/man/rasterise.Rd
@@ -28,7 +28,7 @@ rasterize(
 
 \item{dev}{A character specifying a device. Can be one of: \code{"cairo"}, \code{"ragg"} or \code{"ragg_png"}. (default="cairo")}
 
-\item{scale}{A numeric of length one, setting the scaling factor (default=1). Values > 1 will render the plot as if it was plotted in a larger window.}
+\item{scale}{numeric Scaling factor to modify the raster object size (default=1). The parameter 'scale=1' results in an object size that is unchanged, 'scale'>1 increase the size, and 'scale'<1 decreases the size. These parameters are passed to 'height' and 'width' of grid::grid.raster(). Please refer to 'rasterise()' and 'grid::grid.raster()' for more details.}
 }
 \value{
 A modified \code{Layer} object.

--- a/man/rasterise.Rd
+++ b/man/rasterise.Rd
@@ -28,7 +28,7 @@ rasterize(
 
 \item{dev}{A character specifying a device. Can be one of: \code{"cairo"}, \code{"ragg"} or \code{"ragg_png"}. (default="cairo")}
 
-\item{scale}{A numeric of length one, setting the scaling factor (default=1)}
+\item{scale}{A numeric of length one, setting the scaling factor (default=1). Values > 1 will render the plot as if it was plotted in a larger window.}
 }
 \value{
 A modified \code{Layer} object.

--- a/man/rasterise.Rd
+++ b/man/rasterise.Rd
@@ -6,9 +6,19 @@
 \title{Rasterise ggplot layers
 Takes a ggplot layer as input and renders their graphical output as a raster.}
 \usage{
-rasterise(layer, dpi = getOption("ggrastr.default.dpi"), dev = "cairo")
+rasterise(
+  layer,
+  dpi = getOption("ggrastr.default.dpi"),
+  dev = "cairo",
+  scale = 1
+)
 
-rasterize(layer, dpi = getOption("ggrastr.default.dpi"), dev = "cairo")
+rasterize(
+  layer,
+  dpi = getOption("ggrastr.default.dpi"),
+  dev = "cairo",
+  scale = 1
+)
 }
 \arguments{
 \item{layer}{A \code{Layer} object, typically constructed with a call to a
@@ -17,6 +27,8 @@ rasterize(layer, dpi = getOption("ggrastr.default.dpi"), dev = "cairo")
 \item{dpi}{An integer of length one setting the desired resolution in dots per inch. (default=NULL)}
 
 \item{dev}{A character specifying a device. Can be one of: \code{"cairo"}, \code{"ragg"} or \code{"ragg_png"}. (default="cairo")}
+
+\item{scale}{A numeric of length one, setting the scaling factor (default=1)}
 }
 \value{
 A modified \code{Layer} object.
@@ -42,6 +54,10 @@ ggplot(faithful, aes(eruptions, waiting)) +
 require(ragg)
 ggplot(diamonds, aes(carat, depth, z = price)) +
   rasterise(stat_summary_hex(), dev = "ragg")
+
+# The `scale` argument allows you to render a 'big' plot in small window, or vice versa.
+ggplot(faithful, aes(eruptions, waiting)) +
+  rasterise(geom_point(), scale = 4)
 
 }
 \author{


### PR DESCRIPTION
Thanks for your work on this package! I find it very useful for preparing figures which I later want to edit in a vector graphics program. One feature I liked about the previous version was the raster.width and raster.height arguments which let me put a 'big figure' in a small plot. This is especially useful with geom_point as otherwise the `size` argument doesn't really work and the dots can get quiet big. For my own use, I forked a copy of the package and added a `scale` argument to `rasterise` which adjusts raster dimensions by multiplying the height and width.  By default, `scale = 1` which preserves the current behavior. I've only really tested it with geom_point but I can't see a reason it would be geom specific. 

Would you consider adding this to the main package? I've included an example below. 
```{r}
library(ggplot2)
library(ggrastr)

plot <- ggplot(diamonds, aes(carat, price, colour = cut))
plot + rasterise(geom_point(), dpi = 300, scale = 1)
```
![image](https://user-images.githubusercontent.com/22528952/109016105-6e637980-767b-11eb-8dc7-59909ef9bda2.png)
```{r}
plot + rasterise(geom_point(), dpi = 300, scale = 2)
```
![image](https://user-images.githubusercontent.com/22528952/109016253-96eb7380-767b-11eb-8ae8-240e984b87bd.png)

```{r}
plot + rasterise(geom_point(), dpi = 300, scale = 0.5)
```
![image](https://user-images.githubusercontent.com/22528952/109016323-b1255180-767b-11eb-9004-376b5ca87192.png)

